### PR TITLE
fix errors with import syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-proper-import-require",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Overview

Fixes the following import statements from crashing tslint.

```
import foo from 'bar';
import foo, { bar } from 'baz';
import { foo } from 'bar';
```