### PR TITLE
Catch if require can't resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-proper-import-require",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/rules/properImportRequireRule.ts
+++ b/rules/properImportRequireRule.ts
@@ -23,8 +23,11 @@ function findModulePath(module_name: string): string {
 function loadMainFile(module_name: string): string | undefined {
   const module_path = findModulePath(module_name);
   if (!module_path) return;
-
-  return fs.readFileSync(require.resolve(module_path), 'utf8');
+  try {
+    return fs.readFileSync(require.resolve(module_path), 'utf8');
+  } catch {
+    return;
+  }
 }
 
 // The walker takes care of all the work.


### PR DESCRIPTION
## Overview

Wraps `require.resolve` in a try/catch for when it throws when a module is not resolvable, in our case our schema module.